### PR TITLE
Ali/prereqs constraint

### DIFF
--- a/src/classes/constrain/profile.py
+++ b/src/classes/constrain/profile.py
@@ -1,5 +1,5 @@
 class Profile:
-    
+    """User-set constraints for the solver"""
     def __init__(self, max_quarter_units: int):
         self._max_quarter_units = max_quarter_units
         

--- a/src/classes/constrain/program.py
+++ b/src/classes/constrain/program.py
@@ -2,7 +2,7 @@ from classes.components.course import Course
 from typing import List
 
 class Program:
-    
+    """Degree program with required courses."""
     def __init__(self, required_courses: List[Course]):
         self._required_courses = required_courses
     

--- a/src/classes/solver_config.py
+++ b/src/classes/solver_config.py
@@ -6,11 +6,18 @@ from classes.components.enums import Quarter
 from typing import Dict
 
 class SolverConfig:
-    
-    def __init__(self, 
-                 program: Program, 
-                 profile: Profile = None):
-        
+    """
+    Configures the solver with required courses and constraints.
+
+    Attributes:
+        program (Program): Degree program.
+        profile (Profile): Student profile.
+    """
+    def __init__(
+        self, 
+        program: Program, 
+        profile: Profile = None
+    ) -> None:
         self._program = program
         self._profile = profile
         
@@ -26,14 +33,12 @@ class SolverConfig:
         
     # Add required courses to solver
     def add_required_courses_constraints(self):
-        
         for courseVar, course in self._course_dict.items():
             self._solver.add(Or([courseVar == quarter.value for quarter in course.offered_quarters])) 
     
     # Add prerequisite constraints to solver
     def add_prerequisite_constraints(self):
         pass
-        
 
     # Add quarter load constraints to solver
     def add_quarter_load_constraints(self):

--- a/src/classes/solver_config.py
+++ b/src/classes/solver_config.py
@@ -4,6 +4,7 @@ from classes.constrain.profile import Profile
 from classes.components.course import Course
 from classes.components.enums import Quarter
 from typing import Dict
+from collections import defaultdict
 
 class SolverConfig:
     """
@@ -12,6 +13,8 @@ class SolverConfig:
     Attributes:
         program (Program): Degree program.
         profile (Profile): Student profile.
+        course_dict (Dict[Int, Course]): Dictionary of course codes to course objects.
+        prereq_graph (Dict[Int, Set[Int]]): Dictionary of course codes to prerequisite course codes.
     """
     def __init__(
         self, 
@@ -26,7 +29,13 @@ class SolverConfig:
         self._course_dict: Dict[Int, Course] = {}
         for course in self._program.required_courses:
             self._course_dict[Int(course.code)] = course
-    
+
+        self._prereq_graph = defaultdict(set)
+        for course in self._program.required_courses:
+            for prereq in course.prereqs:
+                if prereq.code in self._course_dict:
+                    self._prereq_graph[course.code].add(prereq.code)
+
     # Returns if the problem is solvable
     def check_solvable(self):
         return self._solver.check()
@@ -35,13 +44,30 @@ class SolverConfig:
     def add_required_courses_constraints(self):
         for courseVar, course in self._course_dict.items():
             self._solver.add(Or([courseVar == quarter.value for quarter in course.offered_quarters])) 
-    
+
     # Add prerequisite constraints to solver
     def add_prerequisite_constraints(self):
-        pass
+        for course_code, prereqs in self._prereq_graph.items():
+            course_var = Int(course_code)
+            for prereq_code in prereqs:
+                prereq_var = Int(prereq_code)
+                self._solver.add(prereq_var < course_var)
 
     # Add quarter load constraints to solver
     def add_quarter_load_constraints(self):
         for quarter in Quarter:
             load = sum([If(courseVar == quarter.value, course.units, 0) for courseVar, course in self._course_dict.items()])
             self._solver.add(load <= self._profile.max_quarter_units)
+
+    def solve(self):
+        if self.check_solvable() == sat:
+            model = self._solver.model()
+            schedule = {}
+            for course in self._program.required_courses:
+                course_var = Int(course.code)
+                quarter_value = model[course_var].as_long()
+                quarter = Quarter(quarter_value)
+                schedule[course] = quarter
+            return schedule
+        else:
+            return None

--- a/src/main.py
+++ b/src/main.py
@@ -6,11 +6,36 @@ from classes.components.enums import Quarter
 
 def main():
     
+    """
+    Setting up a test program for prerequisite requirements before writing unit tests.
+    """
+
+    # Setting up classes
+    MATH21 = Course(code='MATH21', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING])
+    MATH51 = Course(code='MATH51', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[MATH21])
+    MATH52 = Course(code='MATH52', units=5, offered_quarters=[Quarter.WINTER, Quarter.SPRING], prereqs=[MATH51])
+    MATH56 = Course(code='MATH56', units=4, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING])
+    MATH115 = Course(code='MATH115', units=4, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[MATH51, MATH56])
+    MATH151 = Course(code='MATH151', units=4, offered_quarters=[Quarter.WINTER], prereqs=[MATH52, MATH115])
+    MATH136 = Course(code='MATH136', units=4, offered_quarters=[Quarter.FALL], prereqs=[MATH151])
+
+
+    # Set up the degree program
+    degreeProgram = Program(required_courses=[CS106B, CS109, CS229])
+
+    constrainProfile = Profile
+
+
+    """
     # Arranging constraint objects
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER])
+        ]
+    )
     constrainProfile = Profile(max_quarter_units=5)
 
     # Creating and configuring solver
@@ -20,8 +45,8 @@ def main():
     
     # Solving
     print(scheduleSolver.check_solvable())
+    """
 
     
-
 if __name__ == '__main__':
     main()

--- a/src/main.py
+++ b/src/main.py
@@ -11,16 +11,13 @@ def main():
     """
 
     # Setting up classes
-    MATH21 = Course(code='MATH21', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING])
-    MATH51 = Course(code='MATH51', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[MATH21])
-    MATH52 = Course(code='MATH52', units=5, offered_quarters=[Quarter.WINTER, Quarter.SPRING], prereqs=[MATH51])
-    MATH56 = Course(code='MATH56', units=4, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING])
-    MATH115 = Course(code='MATH115', units=4, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[MATH51, MATH56])
-    MATH151 = Course(code='MATH151', units=4, offered_quarters=[Quarter.WINTER], prereqs=[MATH52, MATH115])
-    MATH136 = Course(code='MATH136', units=4, offered_quarters=[Quarter.FALL], prereqs=[MATH151])
+    C1 = Course(code='C1', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER])
+    C2 = Course(code='C2', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER])
+    C3 = Course(code='C3', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[C1, C2])
+    C4 = Course(code='C4', units=5, offered_quarters=[Quarter.SPRING], prereqs=[C3])
 
     # Setting up constraint objects
-    degreeProgram = Program(required_courses=[MATH51, MATH52, MATH56, MATH115, MATH151, MATH136])
+    degreeProgram = Program(required_courses=[C1, C2, C3, C4])
     constrainProfile = Profile(max_quarter_units=20)
 
     # Creating and configuring solver
@@ -29,7 +26,19 @@ def main():
     scheduleSolver.add_prerequisite_constraints()
     scheduleSolver.add_quarter_load_constraints()
 
+    #print(scheduleSolver.prereq_graph)
+
+    print(scheduleSolver.get_constraints())
+
     print(scheduleSolver.check_solvable())
+
+    schedule = scheduleSolver.solve()
+
+    if schedule:
+        for course_code, quarter in schedule.items():
+            print(f"{course_code} is scheduled for {quarter}")
+    else:
+        print("No valid schedule found")
 
 
     """

--- a/src/main.py
+++ b/src/main.py
@@ -19,11 +19,17 @@ def main():
     MATH151 = Course(code='MATH151', units=4, offered_quarters=[Quarter.WINTER], prereqs=[MATH52, MATH115])
     MATH136 = Course(code='MATH136', units=4, offered_quarters=[Quarter.FALL], prereqs=[MATH151])
 
+    # Setting up constraint objects
+    degreeProgram = Program(required_courses=[MATH51, MATH52, MATH56, MATH115, MATH151, MATH136])
+    constrainProfile = Profile(max_quarter_units=20)
 
-    # Set up the degree program
-    degreeProgram = Program(required_courses=[CS106B, CS109, CS229])
+    # Creating and configuring solver
+    scheduleSolver = SolverConfig(program=degreeProgram, profile=constrainProfile)
+    scheduleSolver.add_required_courses_constraints()
+    scheduleSolver.add_prerequisite_constraints()
+    scheduleSolver.add_quarter_load_constraints()
 
-    constrainProfile = Profile
+    print(scheduleSolver.check_solvable())
 
 
     """

--- a/tests/solver_test.py
+++ b/tests/solver_test.py
@@ -8,10 +8,14 @@ from z3 import sat, unsat
 
 def test_add_required_courses_constraints_sat():
     
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
+        ]
+    )
     
     # Creating and configuring solver
     scheduleSolver = SolverConfig(program=degreeProgram)
@@ -21,10 +25,14 @@ def test_add_required_courses_constraints_sat():
     
 def test_add_required_courses_constraints_one_per_quarter_sat():
     
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
+        ]
+    )
     
     constrainProfile = Profile(max_quarter_units=5)
     
@@ -37,10 +45,14 @@ def test_add_required_courses_constraints_one_per_quarter_sat():
     
 def test_add_required_courses_constraints_one_per_quarter_unsat():
     
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
+        ]
+    )
     
     constrainProfile = Profile(max_quarter_units=4)
     
@@ -53,14 +65,18 @@ def test_add_required_courses_constraints_one_per_quarter_unsat():
 
 def test_add_required_courses_constraints_multiple_per_quarter_sat():
     
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
-                            Course(code='C5', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C6', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C7', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C8', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
+            Course(code='C5', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C6', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C7', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C8', units=5, offered_quarters=[Quarter.SUMMER]),
+        ]
+    )
     
     constrainProfile = Profile(max_quarter_units=10)
     
@@ -73,14 +89,18 @@ def test_add_required_courses_constraints_multiple_per_quarter_sat():
     
 def test_add_required_courses_constraints_multiple_per_quarter_unsat():
     
-    degreeProgram = Program(required_courses=[Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
-                            Course(code='C5', units=5, offered_quarters=[Quarter.FALL]),
-                            Course(code='C6', units=5, offered_quarters=[Quarter.WINTER]),
-                            Course(code='C7', units=6, offered_quarters=[Quarter.SPRING]),
-                            Course(code='C8', units=5, offered_quarters=[Quarter.SUMMER])])
+    degreeProgram = Program(
+        required_courses=[
+            Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C2', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C3', units=5, offered_quarters=[Quarter.SPRING]),
+            Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
+            Course(code='C5', units=5, offered_quarters=[Quarter.FALL]),
+            Course(code='C6', units=5, offered_quarters=[Quarter.WINTER]),
+            Course(code='C7', units=6, offered_quarters=[Quarter.SPRING]),
+            Course(code='C8', units=5, offered_quarters=[Quarter.SUMMER]),
+        ]
+    )
     
     constrainProfile = Profile(max_quarter_units=10)
     

--- a/tests/solver_test.py
+++ b/tests/solver_test.py
@@ -90,6 +90,3 @@ def test_add_required_courses_constraints_multiple_per_quarter_unsat():
     scheduleSolver.add_quarter_load_constraints()
     
     assert scheduleSolver.check_solvable() == unsat
-    
-    
-    

--- a/tests/solver_test.py
+++ b/tests/solver_test.py
@@ -7,7 +7,6 @@ from z3 import sat, unsat
 
 
 def test_add_required_courses_constraints_sat():
-    
     degreeProgram = Program(
         required_courses=[
             Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
@@ -24,7 +23,6 @@ def test_add_required_courses_constraints_sat():
     assert scheduleSolver.check_solvable() == sat
     
 def test_add_required_courses_constraints_one_per_quarter_sat():
-    
     degreeProgram = Program(
         required_courses=[
             Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
@@ -44,7 +42,6 @@ def test_add_required_courses_constraints_one_per_quarter_sat():
     assert scheduleSolver.check_solvable() == sat
     
 def test_add_required_courses_constraints_one_per_quarter_unsat():
-    
     degreeProgram = Program(
         required_courses=[
             Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
@@ -53,7 +50,7 @@ def test_add_required_courses_constraints_one_per_quarter_unsat():
             Course(code='C4', units=5, offered_quarters=[Quarter.SUMMER]),
         ]
     )
-    
+
     constrainProfile = Profile(max_quarter_units=4)
     
     # Creating and configuring solver
@@ -64,7 +61,6 @@ def test_add_required_courses_constraints_one_per_quarter_unsat():
     assert scheduleSolver.check_solvable() == unsat
 
 def test_add_required_courses_constraints_multiple_per_quarter_sat():
-    
     degreeProgram = Program(
         required_courses=[
             Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
@@ -88,7 +84,6 @@ def test_add_required_courses_constraints_multiple_per_quarter_sat():
     assert scheduleSolver.check_solvable() == sat
     
 def test_add_required_courses_constraints_multiple_per_quarter_unsat():
-    
     degreeProgram = Program(
         required_courses=[
             Course(code='C1', units=5, offered_quarters=[Quarter.FALL]),
@@ -108,5 +103,40 @@ def test_add_required_courses_constraints_multiple_per_quarter_unsat():
     scheduleSolver = SolverConfig(program=degreeProgram, profile=constrainProfile)
     scheduleSolver.add_required_courses_constraints()
     scheduleSolver.add_quarter_load_constraints()
+    
+    assert scheduleSolver.check_solvable() == unsat
+
+def test_add_prerequisite_constraints_simple_sat():
+    C1 = Course(code='C1', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER])
+    C2 = Course(code='C2', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER])
+    C3 = Course(code='C3', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER, Quarter.SPRING], prereqs=[C1, C2])
+    C4 = Course(code='C4', units=5, offered_quarters=[Quarter.SPRING], prereqs=[C3])
+    
+    degreeProgram = Program(required_courses=[C1, C2, C3, C4])
+    constrainProfile = Profile(max_quarter_units=20)
+    
+    # Creating and configuring solver
+    scheduleSolver = SolverConfig(program=degreeProgram, profile=constrainProfile)
+    scheduleSolver.add_required_courses_constraints()
+    scheduleSolver.add_prerequisite_constraints()
+    
+    assert scheduleSolver.check_solvable() == sat
+
+def test_add_prerequisite_constraints_simple_unsat():
+            
+    C1 = Course(code='C1', units=5, offered_quarters=[Quarter.FALL, Quarter.WINTER])
+    C2 = Course(code='C2', units=5, offered_quarters=[Quarter.WINTER])
+    C3 = Course(code='C3', units=5, offered_quarters=[Quarter.WINTER], prereqs=[C1, C2])
+    C4 = Course(code='C4', units=5, offered_quarters=[Quarter.SPRING], prereqs=[C3])
+    
+    degreeProgram = Program(required_courses=[C1, C2, C3, C4])
+    constrainProfile = Profile(max_quarter_units=20)
+    
+    # Creating and configuring solver
+    scheduleSolver = SolverConfig(program=degreeProgram, profile=constrainProfile)
+    scheduleSolver.add_required_courses_constraints()
+    
+    # Adding a constraint that makes the problem unsolvable
+    scheduleSolver.add_prerequisite_constraints()
     
     assert scheduleSolver.check_solvable() == unsat


### PR DESCRIPTION
- Added a `_prereq_graph` attribute to `SolverConfig` to store prerequisite relationships between courses in a graph-like data structure
- Implemented `add_prerequisite_constraints()` to `SolverConfig` that adds constraints to the solver as it travels through the graph
- Added `test_add_prerequisite_constraints_simple_sat()` and `test_add_prerequisite_constraints_simple_unsat()` to `./tests/solver_test.py`
- Added `solve()` to `SolverConfig` to return a schedule that assigns quarters to each course
- Added `get_constraints()` and `course_dict` and `prereq_graph` as properties to `SolverConfig` for easier debugging